### PR TITLE
Migrate traefik from v1.7 to v2

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -11,4 +11,5 @@ RUN npm install --production
 
 COPY . .
 
+EXPOSE 3000
 CMD ["npm", "start"]

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -141,9 +141,9 @@ services:
       - internal
 {{/if_eq}}
 
-  traefik:
+  gateway:
     image: traefik
-    container_name: traefik
+    container_name: gateway
     command:
       # - --log.level=DEBUG
       - --api.insecure=true

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -33,11 +33,10 @@ services:
       - zookeeper
 {{/if_eq}}
     labels:
-      - "traefik.enable=true"
-      - "traefik.backend=api"
-      - "traefik.port=3000"
-      - "traefik.frontend.entryPoints=http"
-      - "traefik.frontend.rule=PathPrefix:/"
+      - traefik.enable=true
+      - traefik.port=3000
+      - traefik.http.routers.web-api.rule=Host(`localhost`)
+      - traefik.http.routers.web-api.entrypoints=web
     networks:
       - internal
 
@@ -144,12 +143,16 @@ services:
 {{/if_eq}}
 
   traefik:
-    image: traefik:1.7
+    image: traefik
     container_name: traefik
     command:
-      - "--api"
-      - "--docker"
-      - "--docker.watch"
+      # - --log.level=DEBUG
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - traefik.http.routers.web.rule=Host(`localhost`)
+      - traefik.http.routers.web.entrypoints=web
     labels:
       - "traefik.enable=true"
       - "traefik.backend=traefik"
@@ -158,8 +161,7 @@ services:
       - 3000:80
       - 3001:8080
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /dev/null:/traefik.toml
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     networks:
       - internal
       - default

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -34,7 +34,6 @@ services:
 {{/if_eq}}
     labels:
       - traefik.enable=true
-      - traefik.port=3000
       - traefik.http.routers.web-api.rule=Host(`localhost`)
       - traefik.http.routers.web-api.entrypoints=web
     networks:

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -141,9 +141,9 @@ services:
       - internal
 {{/if_eq}}
 
-  gateway:
-    image: traefik
-    container_name: gateway
+  traefik:
+    image: traefik:v2.0
+    container_name: traefik
     command:
       # - --log.level=DEBUG
       - --api.insecure=true


### PR DESCRIPTION
## WHAT
Migrate from v1 to v2 https://docs.traefik.io/migration/v1-to-v2/

## WHY
- Upgrade traefik
## HOW
- Remove `backend`,`frontend` from v1
- Detect rule base on the domain name (localhost)