### PR TITLE
Using NODE_ENV variable

### DIFF
--- a/template/mixins/db.mixin.js
+++ b/template/mixins/db.mixin.js
@@ -60,7 +60,7 @@ module.exports = function(collection) {
 
 		schema.adapter = new MongoAdapter(process.env.MONGO_URI);
 		schema.collection = collection;
-	} else if (process.env.TEST) {
+	} else if (process.env.NODE_ENV === 'test') {
 		// NeDB memory adapter for testing
 		schema.adapter = new DbService.MemoryAdapter();
 	} else {

--- a/template/test/integration/products.service.spec.js
+++ b/template/test/integration/products.service.spec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST=true;
-
 const { ServiceBroker, Context } = require("moleculer");
 const { ValidationError } = require("moleculer").Errors;
 const TestService = require("../../services/products.service");

--- a/template/test/unit/mixins/db.mixin.spec.js
+++ b/template/test/unit/mixins/db.mixin.spec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST=true;
-
 const { ServiceBroker } = require("moleculer");
 const DbService = require("moleculer-db");
 const DbMixin = require("../../../mixins/db.mixin");

--- a/template/test/unit/services/products.spec.js
+++ b/template/test/unit/services/products.spec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST=true;
-
 const { ServiceBroker, Context } = require("moleculer");
 const { ValidationError } = require("moleculer").Errors;
 const TestService = require("../../../services/products.service");


### PR DESCRIPTION
In this PR:
- [x] Improved test mode detection by using `NODE_ENV` variable instead of `TEST` variable. See https://jestjs.io/docs/en/environment-variables

Follow issues #23 